### PR TITLE
Add scopeByStatus to HasStatuses trait

### DIFF
--- a/src/StatusesServiceProvider.php
+++ b/src/StatusesServiceProvider.php
@@ -6,8 +6,8 @@ namespace Tipoff\Statuses;
 
 use Tipoff\Statuses\Models\Status;
 use Tipoff\Statuses\Models\StatusRecord;
-use Tipoff\Statuses\Policies\StatusRecordPolicy;
 use Tipoff\Statuses\Policies\StatusPolicy;
+use Tipoff\Statuses\Policies\StatusRecordPolicy;
 use Tipoff\Support\TipoffPackage;
 use Tipoff\Support\TipoffServiceProvider;
 

--- a/tests/Unit/Traits/HasStatusesTest.php
+++ b/tests/Unit/Traits/HasStatusesTest.php
@@ -120,7 +120,6 @@ class HasStatusesTest extends TestCase
         $this->assertEquals(['2', '3', '2', '3'], $history);
     }
 
-
     /** @test */
     public function scope_by_status()
     {

--- a/tests/Unit/Traits/HasStatusesTest.php
+++ b/tests/Unit/Traits/HasStatusesTest.php
@@ -120,6 +120,37 @@ class HasStatusesTest extends TestCase
         $this->assertEquals(['2', '3', '2', '3'], $history);
     }
 
+
+    /** @test */
+    public function scope_by_status()
+    {
+        TestModel::createTable();
+
+        $this->actingAs(User::factory()->create());
+
+        Status::publishStatuses('type', ['1', '2', '3', '4', '5']);
+
+        TestModel::factory()->count(20)->create()->each(function (TestModel $model, int $idx) {
+            // Generate history
+            $model->setStatus('1', 'type');
+            if ($idx >= 5) {
+                $model->setStatus('2', 'type');
+                if ($idx >= 10) {
+                    $model->setStatus('3', 'type');
+                    if ($idx >= 15) {
+                        $model->setStatus('4', 'type');
+                    }
+                }
+            }
+        });
+
+        $this->assertEquals(5, TestModel::query()->byStatus(Status::findStatus('type', '1'))->count());
+        $this->assertEquals(5, TestModel::query()->byStatus(Status::findStatus('type', '2'))->count());
+        $this->assertEquals(5, TestModel::query()->byStatus(Status::findStatus('type', '3'))->count());
+        $this->assertEquals(5, TestModel::query()->byStatus(Status::findStatus('type', '4'))->count());
+        $this->assertEquals(0, TestModel::query()->byStatus(Status::findStatus('type', '5'))->count());
+    }
+
     /** @test */
     public function set_unknown_status()
     {


### PR DESCRIPTION
This allows scoping the statusable model by a specific status.  Subquery is used to pull latest status record for given model type, model instance and status type.