### PR TITLE
Nullable Creator #27

### DIFF
--- a/database/migrations/2020_05_08_110000_create_status_records_table.php
+++ b/database/migrations/2020_05_08_110000_create_status_records_table.php
@@ -15,7 +15,7 @@ class CreateStatusRecordsTable extends Migration
             $table->foreignIdFor(app('status'))->index();
             $table->morphs('statusable');
             $table->string('type');     // Typically, full class name for model using status
-            $table->foreignIdFor(app('user'), 'creator_id');
+            $table->foreignIdFor(app('user'), 'creator_id')->nullable();
             $table->timestamp('created_at');
         });
     }


### PR DESCRIPTION
There will be cases where Status Records (#27) will be automatically generated by the application for various stages in the system. As a result, the `creator_id` field should be nullable.